### PR TITLE
Update TODO with timeline and state change tasks

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -26,6 +26,7 @@
  - [x] Support multi-dump comparison and timeline of thread states.
  - [ ] Visualize state timeline in the web UI.
 - [x] Highlight new and disappeared threads across dumps.
+- [ ] Highlight threads whose state changed across dumps.
 - [x] Show thread diff results in CLI and web UI.
  - [x] Display thread diff results in the web UI.
 - [x] Create `AnalysisSession` model to manage multiple `ThreadDump` objects.
@@ -54,6 +55,7 @@
 - [x] Add CLI command to display stack trace hotspots.
 - [x] Add CLI option `--output-json` to export analysis results in JSON format.
 - [x] Add CLI option `--open` to automatically launch generated HTML reports in the default browser.
+- [ ] Add CLI option `--label <NAME>` to assign a custom label to a thread dump.
 
 ## Web Interface
  - [x] Launch embedded Jetty server with upload form for thread dump files.
@@ -76,10 +78,14 @@
 - [x] Allow configuring the web server port via CLI option or environment variable.
  - [x] Bind web server to localhost by default to avoid remote exposure.
 - [ ] Allow managing multiple analysis sessions in the web UI.
+- [ ] Allow setting custom labels for uploaded dumps.
+- [ ] Enable selecting two specific dumps for side-by-side diff view.
+- [ ] Link waiting threads to the owning thread of each blocking lock in the UI.
 
 ## Visualization
 - [ ] Provide flame graph visualization for stack trace hotspots.
 - [ ] Add timeline chart showing thread state counts across multiple dumps.
+- [ ] Show per-thread state timeline across multiple dumps.
 - [ ] Include legend for chart color codes in the UI.
 
 ## Testing


### PR DESCRIPTION
## Summary
- add todo to highlight threads that change state across dumps
- plan a per-thread timeline visualization

## Testing
- `mvn -q test` *(fails: AndroidArtParserTest)*

------
https://chatgpt.com/codex/tasks/task_e_68431fbd4b0c83319647188b4e0b1540